### PR TITLE
Updated clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -6,10 +6,6 @@ Language: Cpp
 ColumnLimit: 150
 AccessModifierOffset: 0
 AlignAfterOpenBracket: Align
-AlignConsecutiveAssignments: Consecutive
-AlignConsecutiveBitFields: Consecutive
-AlignConsecutiveDeclarations: Consecutive
-AlignConsecutiveMacros: Consecutive
 AlignEscapedNewlines: Left
 AlignOperands: Align
 AlignTrailingComments: true


### PR DESCRIPTION
## Describe the Pull Request
<!-- A clear and concise description of what the pull request is about. -->

This pull request changes the Clang-format file, to make it no longer align all assignments, type declarations, etc.
Thanks to @jovanivanovic for his contribution.

## To-Do

- [ ] Format current files with new rules

## Affected Platforms
<!-- Point out which platforms this pull request affects -->

- [ ] Windows
- [ ] Linux
- [ ] macOS